### PR TITLE
Fix react children only error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,34 +30,36 @@ const App = () => (
       <ThemeProvider>
         <AuthProvider>
           <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <ParticleSystem 
-            intensity="medium" 
-            interactive={true}
-            className="animate-fade-in"
-          />
-          <BrowserRouter>
-            <Navigation />
-            <main className="lg:ml-72 pt-16 relative z-10">
-              <Routes>
-                <Route path="/" element={<Index />} />
-                <Route path="/overwatch" element={<OverWatch />} />
-                <Route path="/pavement-scan" element={<PavementScan />} />
-                <Route path="/atlas-hub" element={<AtlasHub />} />
-                <Route path="/crew-management" element={<CrewManagement />} />
-                <Route path="/weather-station" element={<WeatherStation />} />
-                <Route path="/cost-control" element={<CostControl />} />
-                <Route path="/mobile-app" element={<MobileApp />} />
-                <Route path="/ai-optimization" element={<AIOptimization />} />
-                <Route path="/reporting-analytics" element={<ReportingAnalytics />} />
-                <Route path="/security-compliance" element={<SecurityCompliance />} />
-                <Route path="/settings" element={<Settings />} />
-                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </main>
-          </BrowserRouter>
+            <>
+              <Toaster />
+              <Sonner />
+              <ParticleSystem 
+                intensity="medium" 
+                interactive={true}
+                className="animate-fade-in"
+              />
+              <BrowserRouter>
+                <Navigation />
+                <main className="lg:ml-72 pt-16 relative z-10">
+                  <Routes>
+                    <Route path="/" element={<Index />} />
+                    <Route path="/overwatch" element={<OverWatch />} />
+                    <Route path="/pavement-scan" element={<PavementScan />} />
+                    <Route path="/atlas-hub" element={<AtlasHub />} />
+                    <Route path="/crew-management" element={<CrewManagement />} />
+                    <Route path="/weather-station" element={<WeatherStation />} />
+                    <Route path="/cost-control" element={<CostControl />} />
+                    <Route path="/mobile-app" element={<MobileApp />} />
+                    <Route path="/ai-optimization" element={<AIOptimization />} />
+                    <Route path="/reporting-analytics" element={<ReportingAnalytics />} />
+                    <Route path="/security-compliance" element={<SecurityCompliance />} />
+                    <Route path="/settings" element={<Settings />} />
+                    {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                    <Route path="*" element={<NotFound />} />
+                  </Routes>
+                </main>
+              </BrowserRouter>
+            </>
           </TooltipProvider>
         </AuthProvider>
       </ThemeProvider>


### PR DESCRIPTION
Wrap `TooltipProvider` children in a React Fragment to resolve the "React.Children.only" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-0039ab8c-391e-4331-a3db-888e4aee943f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0039ab8c-391e-4331-a3db-888e4aee943f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

