### PR TITLE
Handle react children only error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ const App = () => (
       <ThemeProvider>
         <AuthProvider>
           <TooltipProvider>
-            <>
+            <div>
               <Toaster />
               <Sonner />
               <ParticleSystem 
@@ -59,7 +59,7 @@ const App = () => (
                   </Routes>
                 </main>
               </BrowserRouter>
-            </>
+            </div>
           </TooltipProvider>
         </AuthProvider>
       </ThemeProvider>


### PR DESCRIPTION
Replace React Fragment with a div inside TooltipProvider to resolve a runtime error.

The `TooltipProvider` from Radix UI expects exactly one child element via `React.Children.only()`. React Fragments are not considered a single element by this check, leading to the error when multiple children were present within the fragment.

---
<a href="https://cursor.com/background-agent?bcId=bc-71926fdb-f91e-478b-9b28-0cae646e20cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-71926fdb-f91e-478b-9b28-0cae646e20cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

