### PR TITLE
Fix terrain mapper jsx syntax error

### DIFF
--- a/src/components/atlas-hub/TerrainMapper.tsx
+++ b/src/components/atlas-hub/TerrainMapper.tsx
@@ -950,9 +950,9 @@ const TerrainMapper: React.FC<TerrainMapperProps> = ({
                       </div>
                     </div>
                   )}
-                  </div>
-                ))}
-              </div>
+                </div>
+              ))}
+            </div>
 
               {/* View Controls */}
               <div className="mt-6 pt-4 border-t border-glass-border">
@@ -1004,10 +1004,11 @@ const TerrainMapper: React.FC<TerrainMapperProps> = ({
                   onChange={(e) => setViewSettings(prev => ({ ...prev, showAxes: e.target.checked }))}
                   className="rounded"
                 />
-                </div>
               </div>
-              </Card>
-            </TabsContent>
+            </div>
+          </div>
+        </Card>
+      </TabsContent>
 
             {/* Measuring Tools Tab */}
             <TabsContent value="measuring">


### PR DESCRIPTION
Fix JSX syntax errors in `TerrainMapper.tsx` to resolve build failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb69c992-46f7-4de3-be63-73c09f8cecc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb69c992-46f7-4de3-be63-73c09f8cecc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

